### PR TITLE
[#99121462] Feature/deploy postgres app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gem 'rubocop', require: false
 gem 'ruby-jmeter'
 gem 'net-ssh'
 gem 'yajl-ruby', require: 'yajl'
+gem 'aws-sdk'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,8 +4,17 @@ GEM
     ast (2.0.0)
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
+    aws-sdk (2.1.7)
+      aws-sdk-resources (= 2.1.7)
+    aws-sdk-core (2.1.7)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.1.7)
+      aws-sdk-core (= 2.1.7)
+    jmespath (1.0.2)
+      multi_json (~> 1.0)
     mime-types (2.6.1)
     mini_portile (0.6.2)
+    multi_json (1.11.0)
     net-ssh (2.9.2)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
@@ -31,6 +40,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk
   net-ssh
   rubocop
   ruby-jmeter

--- a/bulk_deploy/README.md
+++ b/bulk_deploy/README.md
@@ -13,8 +13,8 @@ Usage: bundle exec deploy.rb action [options]
 Example: bundle exec deploy.rb --environment perf-env --host-suffix tsuru2.paas.alphagov.co.uk apply
     -e, --environment=e              Environment [Required]
     -h, --host-suffix=h              Host suffix [Required]
-    -at, --api-token=at              API Token [Required]
-    -st, --search-api-token=st       Search API Token [Required]
+    -T, --api-token=T                API Token [Required]
+    -S, --search-api-token=S         Search API Token [Required]
     -t, --team-count=t               Team count [Default: 2]
     -u, --users-per-team=u           Users per team [Default: 7]
     -a, --apps-per-team=a            Applications per team [Default: 5]
@@ -44,7 +44,7 @@ Sample Usage
 ------------
 
 ```
-bundle exec ruby deploy.rb -e richard -h tsuru2.paas.alphagov.co.uk apply -t 2 -n 3 -T ourtoken -S oursearchtoken
+bundle exec ruby deploy.rb -e richard -h tsuru2.paas.alphagov.co.uk -t 2 -n 3 -T ourtoken -S oursearchtoken -c /path/to/ssh.config apply
 ```
 
 Will create 2 teams, each with 7 users and deploy 5 apps (listed above) for the each team with 3 units per app.

--- a/bulk_deploy/README.md
+++ b/bulk_deploy/README.md
@@ -43,6 +43,16 @@ In the future we want to improve this script to deploy our own DM backend apps w
 Sample Usage
 ------------
 
+Make sure you have these in your profile:
+
+```
+export AWS_ACCESS_KEY_ID=hello
+export AWS_SECRET_ACCESS_KEY=howareyou
+export AWS_REGION=eu-west-1
+```
+
+If you don't, add them to `~/.bash_profile` and run `source ~/.bash_profile`.
+
 ```
 bundle exec ruby deploy.rb -e richard -h tsuru2.paas.alphagov.co.uk -t 2 -n 3 -T ourtoken -S oursearchtoken -c /path/to/ssh.config apply
 ```

--- a/bulk_deploy/deploy.rb
+++ b/bulk_deploy/deploy.rb
@@ -15,7 +15,7 @@ help = false
 parser = OptionParser.new do |opts|
   script_name = File.basename($0)
   opts.banner = "Usage: bundle exec #{script_name} action [options]"
-  opts.define_head "Example: bundle exec #{script_name} --environment perf-env --host-suffix tsuru2.paas.alphagov.co.uk apply"
+  opts.define_head "Example: bundle exec #{script_name} -e perf-env -h tsuru2.paas.alphagov.co.uk -c ~/github.com/alphagov/tsuru-ansible/ssh.config -T ourtoken -S oursearchtoken apply"
 
   opts.on("-e", "--environment=e", "Environment [Required]") do |e|
     options[:environment] = e
@@ -28,6 +28,9 @@ parser = OptionParser.new do |opts|
   end
   opts.on("-S", "--search-api-token=S", "Search API token [Required]") do |s|
     options[:search_api_token] = s
+  end
+  opts.on("-c", "--ssh-config=c", "SSH Config File [Required]") do |h|
+    options[:ssh_config] = h
   end
   opts.on("-t", "--team-count=t", Integer, "Team count [Default: #{options[:team_count]}]") do |t|
     options[:team_count] = t
@@ -65,6 +68,7 @@ begin
     # Tokens are only needed for apply action
     raise "Error: Missing option: api_token" unless options[:api_token]
     raise "Error: Missing option: search_api_token" unless options[:search_api_token]
+    raise "Error: Missing option: ssh_config" unless options[:ssh_config]
   end
   unless options[:users_per_team] >= options[:apps_per_team]
     raise "Error: Number of users number must greater or equal to number of applications (#{options[:apps_per_team]})"

--- a/bulk_deploy/deploy_actions.rb
+++ b/bulk_deploy/deploy_actions.rb
@@ -24,7 +24,7 @@ class DeployActions
         raise "Error: Unknown log level: #{options[:log_level]}"
     end
 
-    @tsuru_home = '/tmp/tsuru_tmp'
+    @tsuru_home = Dir.mktmpdir
     ENV["HOME"] = @tsuru_home
   end
 
@@ -274,8 +274,10 @@ class DeployActions
       @logger.info("Write state file #{state_file}")
       File.open(state_file, 'w') { |file| file.write(state_string) }
     end
-  end
 
+  ensure
+    FileUtils.remove_entry @tsuru_home
+  end
 
   def destroy()
     environment    = @options[:environment]

--- a/bulk_deploy/tsuru_api_client.rb
+++ b/bulk_deploy/tsuru_api_client.rb
@@ -197,6 +197,10 @@ class TsuruAPIClient
     )
   end
 
+  def get_app_url(app_name)
+    get_app_info(app_name)["ip"]
+  end
+
   def add_units(units, app_name)
     objects = request_json(
       method: :put,
@@ -257,10 +261,18 @@ class TsuruAPIClient
   end
 
   def get_env_vars(app_name)
-    request_json(
+    hash = {}
+
+    env_vars = request_json(
       method: :get,
       path: "/apps/#{app_name}/env",
     )
+
+    for env_var_arr in env_vars
+      hash[env_var_arr["name"]] = env_var_arr["value"]
+    end
+
+    return hash
   end
 
   def unset_env_var(app_name, key, value)

--- a/bulk_deploy/tsuru_deploy_client.rb
+++ b/bulk_deploy/tsuru_deploy_client.rb
@@ -79,11 +79,9 @@ class TsuruDeployClient
   end
 
   def import_pg_dump(app_name, postgres_instance_name, ssh_config)
-    s3 = Aws::S3::Client.new
-
     # Download database dump from S3
     File.open(File.join(@tsuru_home, "full.dump"), "wb") do |file|
-      reap = s3.get_object(
+      reap = Aws::S3::Client.new.get_object(
         {
           bucket:"digital-marketplace-stuff",
           key: "full.dump"
@@ -94,24 +92,19 @@ class TsuruDeployClient
 
     postgres_ip = @api_client.get_env_vars(app_name)["PG_HOST"]
     db_name = @api_client.get_env_vars(app_name)["PG_DATABASE"]
-
-    # Create a symbolic link to ssh.config in our temporary directory
-    if !File.exists?("#{@tsuru_home}/ssh.config")
-      if !system("ln -s #{ssh_config} #{@tsuru_home}/ssh.config")
-        raise "Failed to create a symbolic link to ssh.config file"
-      end
-    end
+    ssh_config_dir = File.dirname(File.expand_path(ssh_config))
 
     # Use scp to upload the database dump to posgres box
-    scp_cmd = "cd #{@tsuru_home} && scp -F ssh.config full.dump #{postgres_ip}:~/full.dump"
+    scp_cmd = "cd #{ssh_config_dir} && scp -F ssh.config "\
+              "#{@tsuru_home}/full.dump #{postgres_ip}:~/full.dump"
     self.logger.info("SCP postgres dump file over: #{scp_cmd}")
     if !system(scp_cmd)
       raise "Failed to upload database dump via scp"
     end
 
     # Run pg_restore on the postgres box to load the data
-    restore_cmd = "cd #{@tsuru_home} && ssh -F ssh.config #{postgres_ip} "\
-                  "'pg_restore -a -U postgres -d #{db_name} -Fc ~/full.dump'"
+    restore_cmd = "cd #{ssh_config_dir} && ssh -F ssh.config #{postgres_ip} "\
+                  "'pg_restore -a -U postgres -d #{db_name} -a --disable-triggers ~/full.dump'"
     self.logger.info("Let's restore the data from backup: #{restore_cmd}")
     system(restore_cmd)
   end


### PR DESCRIPTION
## What

This PR adds deployment of one of Digital Marketplace backend apps to the deployment script.

The script populates the database of created apps by importing a dump of data stored in S3 bucket.

Some changes have been made to the deployment script. There is a new required parameter specifying the path to ssh.config file. This is required in order to be able to scp database dump to Postgres database instance and run pg_restore.

This script requires you to have Boto working as it uses Python script to download database dump from S3 bucket. You should already have your AWS id and secret key in your ~/.bash_profile but if you don't, set them.

```
export AWS_ACCESS_KEY_ID=hello
export AWS_SECRET_ACCESS_KEY=howareyou
export AWS_REGION=eu-west-1
```

This PR depends on https://github.com/alphagov/tsuru-performance-tests/pulls to be merged first.
## Usage

```
bundle exec ruby deploy.rb -e richard -h tsuru2.paas.alphagov.co.uk apply -t 2 -n 3 -T apitoken -S searchapitoken -c /path/to/ssh.config
```

Will create 2 teams, each with 7 users and deploy 5 apps (listed above) for the each team with 3 units per app.

It will use `richard` environment on GCE.

Deployed apps can be removed by running the destroy command:

```
bundle exec ruby deploy.rb -e richard -h tsuru2.paas.alphagov.co.uk destroy -t 2 -n 3
```
## Review

Anybody except Martin and Jim should review this PR.
