### PR TITLE
[#99680570] Feature/populate elastic search

### DIFF
--- a/bulk_deploy/Rakefile
+++ b/bulk_deploy/Rakefile
@@ -321,7 +321,7 @@ namespace "apps" do
           platform: "python"
         },
         env_vars: {
-          DM_SEARCH_API_AUTH_TOKEN: search_api_token,
+          DM_SEARCH_API_AUTH_TOKENS: search_api_token,
         },
         elasticsearch: servicename,
         units: UNITS_PER_APP
@@ -384,16 +384,6 @@ namespace "apps" do
 
       LOGGER.info("Importing #{pg_dump_url} in service of #{appname}")
       deploy_client.import_pg_dump(appname, pg_dump_url, pg_dump_auth_header)
-    end
-
-    desc "Import Data To Elasticsearch"
-    task "import_elasticsearch" do |t, args|
-      teamname = args[:teamname]
-      username = args[:username]
-      deploy_client = get_deploy_client(username)
-      from_appname = "dm-api-#{teamname}"
-      to_appname = "dm-search0api-#{teamname}"
-      deploy_client.import_elasticsearch_data(from_appname, to_appname)
     end
 
     # Aggregates both tasks
@@ -557,6 +547,17 @@ namespace "apps" do
       )
     end
   end
+  namespace "post-deploy-tasks" do
+    teamname = gen_team_name(1)
+    username = gen_username(teamname, 1)
+    desc "Import Data To Elasticsearch"
+    task "import_elasticsearch" do |t, args|
+      deploy_client = get_deploy_client(username)
+      from_appname = "dm-api-#{teamname}"
+      to_appname = "dm-search-api-#{teamname}"
+      deploy_client.import_elasticsearch_data(from_appname, to_appname)
+    end
+  end
 
 end
 
@@ -656,6 +657,16 @@ namespace "team_deployment" do
 end
 
 desc "Bring up all the environment"
-task "deploy" => [ "clone:all", "teams:create_all", "pre_app_deploy:postgresapi_set_web_concurrency", "team_deployment:deploy_parallel" ]
+task "deploy" => [
+  "clone:all",
+  "teams:create_all",
+  "pre_app_deploy:postgresapi_set_web_concurrency"
+  "team_deployment:deploy_parallel",
+  "apps:post-deploy-tasks:import_elasticsearch"
+]
 desc "Bring down all the environment"
-task "destroy" => [ "team_deployment:remove_parallel", "teams:remove_all", "workdir:clean" ]
+task "destroy" => [
+  "team_deployment:remove_parallel",
+  "teams:remove_all",
+  "workdir:clean"
+]

--- a/bulk_deploy/Rakefile
+++ b/bulk_deploy/Rakefile
@@ -493,7 +493,7 @@ namespace "apps" do
         units: UNITS_PER_APP
       )
     end
-    desc "Remove Datamarket Admin frontend - dm-buyer-frontend"
+    desc "Remove Datamarket Admin frontend - dm-admin-frontend"
     task "remove", [ :teamname, :username ] do |t, args|
       teamname = args[:teamname]
       username = args[:username]
@@ -608,4 +608,3 @@ desc "Bring up all the environment"
 task "deploy" => [ "clone:all", "teams:create_all", "pre_app_deploy:postgresapi_set_web_concurrency", "team_deployment:deploy_parallel" ]
 desc "Bring down all the environment"
 task "destroy" => [ "team_deployment:remove_parallel", "teams:remove_all", "workdir:clean" ]
-

--- a/bulk_deploy/Rakefile
+++ b/bulk_deploy/Rakefile
@@ -27,7 +27,6 @@ DEFAULT_USER_PASSWORD = ENV['default_user_password'] || "password"
 # datamarket Specific options
 DM_API_TOKEN = ENV['dm_api_token'] || "ourtoken"
 DM_SEARCH_API_TOKEN = ENV['dm_search_api_token'] || "oursearchtoken"
-DM_SEARCH_API_URL = ENV['dm_search_api_url'] || "https://preview-search-api.development.digitalmarketplace.service.gov.uk"
 
 # stop execution on error
 STOP_ON_ERROR = ENV["stop_on_error"] || false

--- a/bulk_deploy/Rakefile
+++ b/bulk_deploy/Rakefile
@@ -244,18 +244,29 @@ namespace "apps" do
     task :deploy, [ :teamname, :username ] do |t, args|
       teamname = args[:teamname]
       username = args[:username]
-      deploy_client = get_deploy_client(username)
       appname = "flask-app-#{teamname}"
       servicename = "#{teamname}-flask-app-db"
+
       LOGGER.info("#{teamname}: Deploying #{appname} with service #{servicename}")
-      deploy_client.deploy_app(
+      get_deploy_client(username).deploy_app(
         app: {
           name: appname,
           dir: File.join(REPOS_DIR, "flask-sqlalchemy-postgres-heroku-example"),
           platform: "python"
         },
         postgres: servicename,
-        git: true,
+        git: true
+      )
+    end
+    desc "Post deploy actions for flask-app"
+    task :post_deploy, [ :teamname, :username ] do |t, args|
+      teamname = args[:teamname]
+      username = args[:username]
+      appname = "flask-app-#{teamname}"
+      @api_client.unlock_app(appname)
+      deploy_client = get_deploy_client(username)
+      deploy_client.add_units(
+        app_name: appname,
         units: UNITS_PER_APP
       )
     end
@@ -263,17 +274,13 @@ namespace "apps" do
     task "remove", [ :teamname, :username ] do |t, args|
       teamname = args[:teamname]
       username = args[:username]
-      deploy_client = get_deploy_client(username)
       appname = "flask-app-#{teamname}"
+      deploy_client = get_deploy_client(username)
       servicename = "#{teamname}-flask-app-db"
 
       LOGGER.info("#{teamname}: Removing #{appname} with service #{servicename}")
       deploy_client.remove_app(
-        app: {
-          name: appname,
-          dir: File.join(REPOS_DIR, "flask-sqlalchemy-postgres-heroku-example"),
-          platform: "python"
-        },
+        app_name: appname,
         postgres: servicename
       )
     end
@@ -283,16 +290,26 @@ namespace "apps" do
     task :deploy, [ :teamname, :username ] do |t, args|
       teamname = args[:teamname]
       username = args[:username]
-      deploy_client = get_deploy_client(username)
       appname = "java-app-#{teamname}"
 
       LOGGER.info("#{teamname}: Deploying #{appname}")
-      deploy_client.deploy_app(
+      get_deploy_client(username).deploy_app(
         app: {
           name: appname,
           dir: File.join(REPOS_DIR, "example-java-jetty"),
           platform: "java"
-        },
+        }
+      )
+    end
+    desc "Post deploy actions for java-app"
+    task :post_deploy, [ :teamname, :username ] do |t, args|
+      teamname = args[:teamname]
+      username = args[:username]
+      appname = "java-app-#{teamname}"
+      @api_client.unlock_app(appname)
+
+      get_deploy_client(username).add_units(
+        app_name: appname,
         units: UNITS_PER_APP
       )
     end
@@ -300,15 +317,11 @@ namespace "apps" do
     task "remove", [ :teamname, :username ] do |t, args|
       teamname = args[:teamname]
       username = args[:username]
-      deploy_client = get_deploy_client(username)
       appname = "java-app-#{teamname}"
+      deploy_client = get_deploy_client(username)
 
       LOGGER.info("#{teamname}: Removing #{appname}")
-      deploy_client.remove_app(
-        app: {
-          name: appname,
-        }
-      )
+      deploy_client.remove_app(app_name: appname)
     end
   end
   namespace "dm-search-api" do
@@ -316,23 +329,31 @@ namespace "apps" do
     task "deploy", [ :teamname, :username ] do |t, args|
       teamname = args[:teamname]
       username = args[:username]
-      deploy_client = get_deploy_client(username)
       appname = "dm-search-api-#{teamname}"
       servicename = "#{teamname}-dm-search-api-elasticsearch"
 
-      search_api_token = DM_SEARCH_API_TOKEN
-
       LOGGER.info("Deploying #{appname}")
-      deploy_client.deploy_app(
+      get_deploy_client(username).deploy_app(
         app: {
           name: appname,
           dir: File.join(REPOS_DIR, "digitalmarketplace-search-api"),
           platform: "python"
         },
         env_vars: {
-          DM_SEARCH_API_AUTH_TOKENS: search_api_token,
+          DM_SEARCH_API_AUTH_TOKENS: DM_SEARCH_API_TOKEN,
         },
-        elasticsearch: servicename,
+        elasticsearch: servicename
+      )
+    end
+    desc "Post deploy actions for dm-search-api"
+    task :post_deploy, [ :teamname, :username ] do |t, args|
+      teamname = args[:teamname]
+      username = args[:username]
+      appname = "dm-search-api-#{teamname}"
+      @api_client.unlock_app(appname)
+
+      get_deploy_client(username).add_units(
+        app_name: appname,
         units: UNITS_PER_APP
       )
     end
@@ -340,14 +361,11 @@ namespace "apps" do
     task "remove", [ :teamname, :username ] do |t, args|
       teamname = args[:teamname]
       username = args[:username]
-      deploy_client = get_deploy_client(username)
       appname = "dm-search-api-#{teamname}"
       servicename = "#{teamname}-dm-search-api-elasticsearch"
 
-      deploy_client.remove_app(
-        app: {
-          name: appname,
-        },
+      get_deploy_client(username).remove_app(
+        app_name: appname,
         elasticsearch: servicename,
       )
     end
@@ -357,12 +375,9 @@ namespace "apps" do
     task "deploy_app", [ :teamname, :username ] do |t, args|
       teamname = args[:teamname]
       username = args[:username]
-      deploy_client = get_deploy_client(username)
       appname = "dm-api-#{teamname}"
+      deploy_client = get_deploy_client(username)
       servicename = "#{teamname}-dm-api-db"
-
-      api_token = DM_API_TOKEN
-      search_api_token = DM_SEARCH_API_TOKEN
       search_api_url = "https://" + deploy_client.api_client.get_app_url("dm-search-api-#{teamname}")
 
       LOGGER.info("Deploying #{appname}")
@@ -373,26 +388,24 @@ namespace "apps" do
           platform: "python"
         },
         env_vars: {
-          DM_API_AUTH_TOKENS: api_token,
-          DM_SEARCH_API_AUTH_TOKEN: search_api_token,
+          DM_API_AUTH_TOKENS: DM_API_TOKEN,
+          DM_SEARCH_API_AUTH_TOKEN: DM_SEARCH_API_TOKEN,
           DM_SEARCH_API_URL: search_api_url,
         },
-        postgres: servicename,
-        units: UNITS_PER_APP
+        postgres: servicename
       )
     end
     desc "Import Datamarket API postgres DB"
     task "import_pg_dump" do |t, args|
       teamname = args[:teamname]
       username = args[:username]
-      deploy_client = get_deploy_client(username)
       appname = "dm-api-#{teamname}"
 
       pg_dump_url= ENV['dm_api_pg_dump_url'] || raise("You must pass dm_api_pg_dump_url=... with the url to the db dump for DM API")
       pg_dump_auth_header= ENV['dm_api_pg_dump_auth_header'] || raise("You must pass dm_api_pg_dump_auth_header=... with the auth header to access to the db dump for DM API")
 
       LOGGER.info("Importing #{pg_dump_url} in service of #{appname}")
-      deploy_client.import_pg_dump(appname, pg_dump_url, pg_dump_auth_header)
+      get_deploy_client(username).import_pg_dump(appname, pg_dump_url, pg_dump_auth_header)
     end
 
     # Aggregates both tasks
@@ -402,18 +415,28 @@ namespace "apps" do
       task("apps:dm-api:import_pg_dump").execute(args)
     end
 
+    desc "Post deploy actions for dm-api"
+    task :post_deploy, [ :teamname, :username ] do |t, args|
+      teamname = args[:teamname]
+      username = args[:username]
+      appname = "dm-api-#{teamname}"
+      @api_client.unlock_app(appname)
+
+      get_deploy_client(username).add_units(
+        app_name: appname,
+        units: UNITS_PER_APP
+      )
+    end
+
     desc "Remove Datamarket API - dm-api"
     task "remove", [ :teamname, :username ] do |t, args|
       teamname = args[:teamname]
       username = args[:username]
-      deploy_client = get_deploy_client(username)
       appname = "dm-api-#{teamname}"
       servicename = "#{teamname}-dm-api-db"
 
-      deploy_client.remove_app(
-        app: {
-          name: appname,
-        },
+      get_deploy_client(username).remove_app(
+        app_name: appname,
         postgres: servicename,
       )
     end
@@ -423,11 +446,8 @@ namespace "apps" do
     task "deploy", [ :teamname, :username ] do |t, args|
       teamname = args[:teamname]
       username = args[:username]
-      deploy_client = get_deploy_client(username)
       appname = "dm-supplier-frontend-#{teamname}"
-
-      api_token = DM_API_TOKEN
-      search_api_token = DM_SEARCH_API_TOKEN
+      deploy_client = get_deploy_client(username)
       search_api_url = "https://" + deploy_client.api_client.get_app_url("dm-search-api-#{teamname}")
       api_url = "https://" + deploy_client.api_client.get_app_url("dm-api-#{teamname}")
 
@@ -441,14 +461,25 @@ namespace "apps" do
         env_vars: {
           DM_ADMIN_FRONTEND_COOKIE_SECRET: "secret",
           DM_ADMIN_FRONTEND_PASSWORD_HASH: "JHA1azIkMjcxMCRiNWZmMjhmMmExYTM0OGMyYTY0MjA3ZWFkOTIwNGM3NiQ4OGRLTHBUTWJQUE95UEVvSmg3djZYY2tWQ3lpcTZtaw==",
-          DM_DATA_API_AUTH_TOKEN: api_token,
+          DM_DATA_API_AUTH_TOKEN: DM_API_TOKEN,
           DM_DATA_API_URL: api_url,
           DM_MANDRILL_API_KEY: "somekey",
           DM_PASSWORD_SECRET_KEY: "verySecretKey",
           DM_S3_DOCUMENT_BUCKET: "admin-frontend-dev-documents",
-          DM_SEARCH_API_AUTH_TOKEN: search_api_token,
+          DM_SEARCH_API_AUTH_TOKEN: DM_SEARCH_API_TOKEN,
           DM_SEARCH_API_URL: search_api_url
-        },
+        }
+      )
+    end
+    desc "Post deploy actions for dm-supplier-frontend"
+    task :post_deploy, [ :teamname, :username ] do |t, args|
+      teamname = args[:teamname]
+      username = args[:username]
+      appname = "dm-supplier-frontend-#{teamname}"
+      @api_client.unlock_app(appname)
+
+      get_deploy_client(username).add_units(
+        app_name: appname,
         units: UNITS_PER_APP
       )
     end
@@ -456,14 +487,9 @@ namespace "apps" do
     task "remove", [ :teamname, :username ] do |t, args|
       teamname = args[:teamname]
       username = args[:username]
-      deploy_client = get_deploy_client(username)
       appname = "dm-supplier-frontend-#{teamname}"
 
-      deploy_client.remove_app(
-        app: {
-          name: appname,
-        }
-      )
+      get_deploy_client(username).remove_app(app_name: appname)
     end
   end
   namespace "dm-buyer-frontend" do
@@ -471,11 +497,8 @@ namespace "apps" do
     task "deploy", [ :teamname, :username ] do |t, args|
       teamname = args[:teamname]
       username = args[:username]
-      deploy_client = get_deploy_client(username)
       appname = "dm-buyer-frontend-#{teamname}"
-
-      api_token = DM_API_TOKEN
-      search_api_token = DM_SEARCH_API_TOKEN
+      deploy_client = get_deploy_client(username)
       search_api_url = "https://" + deploy_client.api_client.get_app_url("dm-search-api-#{teamname}")
       api_url = "https://" + deploy_client.api_client.get_app_url("dm-api-#{teamname}")
 
@@ -488,12 +511,23 @@ namespace "apps" do
         env_vars: {
           DM_ADMIN_FRONTEND_COOKIE_SECRET: "secret",
           DM_ADMIN_FRONTEND_PASSWORD_HASH: "JHA1azIkMjcxMCRiNWZmMjhmMmExYTM0OGMyYTY0MjA3ZWFkOTIwNGM3NiQ4OGRLTHBUTWJQUE95UEVvSmg3djZYY2tWQ3lpcTZtaw==",
-          DM_DATA_API_AUTH_TOKEN: api_token,
+          DM_DATA_API_AUTH_TOKEN: DM_API_TOKEN,
           DM_DATA_API_URL: api_url,
           DM_S3_DOCUMENT_BUCKET: "admin-frontend-dev-documents",
-          DM_SEARCH_API_AUTH_TOKEN: search_api_token,
+          DM_SEARCH_API_AUTH_TOKEN: DM_SEARCH_API_TOKEN,
           DM_SEARCH_API_URL: search_api_url
-        },
+        }
+      )
+    end
+    desc "Post deploy actions for dm-buyer-frontend"
+    task :post_deploy, [ :teamname, :username ] do |t, args|
+      teamname = args[:teamname]
+      username = args[:username]
+      appname = "dm-buyer-frontend-#{teamname}"
+      @api_client.unlock_app(appname)
+
+      get_deploy_client(username).add_units(
+        app_name: appname,
         units: UNITS_PER_APP
       )
     end
@@ -501,14 +535,9 @@ namespace "apps" do
     task "remove", [ :teamname, :username ] do |t, args|
       teamname = args[:teamname]
       username = args[:username]
-      deploy_client = get_deploy_client(username)
       appname = "dm-buyer-frontend-#{teamname}"
 
-      deploy_client.remove_app(
-        app: {
-          name: appname,
-        }
-      )
+      get_deploy_client(username).remove_app(app_name: appname)
     end
   end
   namespace "dm-admin-frontend" do
@@ -516,11 +545,8 @@ namespace "apps" do
     task "deploy", [ :teamname, :username ] do |t, args|
       teamname = args[:teamname]
       username = args[:username]
-      deploy_client = get_deploy_client(username)
       appname = "dm-admin-frontend-#{teamname}"
-
-      api_token = DM_API_TOKEN
-      search_api_token = DM_SEARCH_API_TOKEN
+      deploy_client = get_deploy_client(username)
       search_api_url = "https://" + deploy_client.api_client.get_app_url("dm-search-api-#{teamname}")
       api_url = "https://" + deploy_client.api_client.get_app_url("dm-api-#{teamname}")
 
@@ -533,12 +559,23 @@ namespace "apps" do
         env_vars: {
           DM_ADMIN_FRONTEND_COOKIE_SECRET: "secret",
           DM_ADMIN_FRONTEND_PASSWORD_HASH: "JHA1azIkMjcxMCRiNWZmMjhmMmExYTM0OGMyYTY0MjA3ZWFkOTIwNGM3NiQ4OGRLTHBUTWJQUE95UEVvSmg3djZYY2tWQ3lpcTZtaw==",
-          DM_DATA_API_AUTH_TOKEN: api_token,
+          DM_DATA_API_AUTH_TOKEN: DM_API_TOKEN,
           DM_DATA_API_URL: api_url,
           DM_S3_DOCUMENT_BUCKET: "admin-frontend-dev-documents",
-          DM_SEARCH_API_AUTH_TOKEN: search_api_token,
+          DM_SEARCH_API_AUTH_TOKEN: DM_SEARCH_API_TOKEN,
           DM_SEARCH_API_URL: search_api_url
-        },
+        }
+      )
+    end
+    desc "Post deploy actions for dm-admin-frontend"
+    task :post_deploy, [ :teamname, :username ] do |t, args|
+      teamname = args[:teamname]
+      username = args[:username]
+      appname = "dm-admin-frontend-#{teamname}"
+      @api_client.unlock_app(appname)
+
+      get_deploy_client(username).add_units(
+        app_name: appname,
         units: UNITS_PER_APP
       )
     end
@@ -546,14 +583,9 @@ namespace "apps" do
     task "remove", [ :teamname, :username ] do |t, args|
       teamname = args[:teamname]
       username = args[:username]
-      deploy_client = get_deploy_client(username)
       appname = "dm-admin-frontend-#{teamname}"
 
-      deploy_client.remove_app(
-        app: {
-          name: appname,
-        }
-      )
+      get_deploy_client(username).remove_app(app_name: appname)
     end
   end
   namespace "post-deploy-tasks" do
@@ -561,10 +593,9 @@ namespace "apps" do
     username = gen_username(teamname, 1)
     desc "Import Data To Elasticsearch"
     task "import_elasticsearch" do |t, args|
-      deploy_client = get_deploy_client(username)
       from_appname = "dm-api-#{teamname}"
       to_appname = "dm-search-api-#{teamname}"
-      deploy_client.import_elasticsearch_data(from_appname, to_appname)
+      get_deploy_client(username).import_elasticsearch_data(from_appname, to_appname)
     end
   end
 
@@ -573,8 +604,8 @@ end
 
 # Generate specific tasks to deploy apps in each team
 app_list = [
-  "flask-app",
   "java-app",
+  "flask-app",
   "dm-search-api",
   "dm-api",
   "dm-supplier-frontend",
@@ -596,6 +627,11 @@ namespace "team_deployment" do
             # With execute you must pass a hash with the arguments
             task("apps:#{app}:deploy").execute(teamname: teamname, username: username)
           end
+          task "post_deploy" => [ "tsuru:login_admin" ] do
+            # Note: there are differences between calling .invoke and .execute
+            # With execute you must pass a hash with the arguments
+            task("apps:#{app}:post_deploy").execute(teamname: teamname, username: username)
+          end
           task "remove" => [ "tsuru:login_admin" ] do
             task("apps:#{app}:remove").execute(teamname: teamname, username: username)
           end
@@ -610,6 +646,23 @@ namespace "team_deployment" do
           rescue Exception => e
             LOGGER.error("Failed running team_deployment:#{teamname}:#{app}:deploy")
             failed_tasks << "team_deployment:#{teamname}:#{app}:deploy"
+            LOGGER.error(e.message)
+            LOGGER.debug(e.backtrace.join("\n\t"))
+            stop_execution if STOP_ON_ERROR
+            break
+          end
+          break if execution_stopped?
+        }
+      end
+      desc "Run post deploy actions for team #{teamname}"
+      task "post_deploy_all" do
+        app_list.map { |app|
+          # Error tolerant per team
+          begin
+            task("team_deployment:#{teamname}:#{app}:post_deploy").invoke
+          rescue Exception => e
+            LOGGER.error("Failed running team_deployment:#{teamname}:#{app}:post_deploy")
+            failed_tasks << "team_deployment:#{teamname}:#{app}:post_deploy"
             LOGGER.error(e.message)
             LOGGER.debug(e.backtrace.join("\n\t"))
             stop_execution if STOP_ON_ERROR
@@ -650,6 +703,19 @@ namespace "team_deployment" do
       abort
     end
   end
+  desc "Do post deploy actions in parallel for all applications and all teams"
+  multitask "post_deploy_parallel" =>
+  (1..NUM_TEAMS).map { |team_i|
+    teamname = gen_team_name(team_i)
+    "team_deployment:#{teamname}:post_deploy_all"
+  } do
+    if failed_tasks.empty?
+      LOGGER.info("Deployment finished OK")
+    else
+      LOGGER.error("Some tasks failed: " + failed_tasks.join(' '))
+      abort
+    end
+  end
   desc "Remove in parallel all applications for all teams"
   multitask "remove_parallel" =>
   (1..NUM_TEAMS).map { |team_i|
@@ -671,6 +737,7 @@ task "deploy" => [
   "teams:create_all",
   "pre_app_deploy:postgresapi_set_web_concurrency",
   "team_deployment:deploy_parallel",
+  "team_deployment:post_deploy_parallel",
   "apps:post-deploy-tasks:import_elasticsearch"
 ]
 desc "Bring down all the environment"

--- a/bulk_deploy/Rakefile
+++ b/bulk_deploy/Rakefile
@@ -616,8 +616,8 @@ namespace "team_deployment" do
           begin
             task("team_deployment:#{teamname}:#{app}:remove").invoke
           rescue Exception => e
-            LOGGER.error("Failed running team_deployment:#{teamname}:#{app}:deploy")
-            failed_tasks << "team_deployment:#{teamname}:#{app}:deploy"
+            LOGGER.error("Failed running team_deployment:#{teamname}:#{app}:remove")
+            failed_tasks << "team_deployment:#{teamname}:#{app}:remove"
             LOGGER.error(e.message)
             LOGGER.debug(e.backtrace.join("\n\t"))
             stop_execution if STOP_ON_ERROR

--- a/bulk_deploy/Rakefile
+++ b/bulk_deploy/Rakefile
@@ -660,7 +660,7 @@ desc "Bring up all the environment"
 task "deploy" => [
   "clone:all",
   "teams:create_all",
-  "pre_app_deploy:postgresapi_set_web_concurrency"
+  "pre_app_deploy:postgresapi_set_web_concurrency",
   "team_deployment:deploy_parallel",
   "apps:post-deploy-tasks:import_elasticsearch"
 ]

--- a/bulk_deploy/Rakefile
+++ b/bulk_deploy/Rakefile
@@ -303,6 +303,47 @@ namespace "apps" do
       )
     end
   end
+  namespace "dm-search-api" do
+    desc "Deploy Datamarket Search API (no es dump) - dm-search-api"
+    task "deploy", [ :teamname, :username ] do |t, args|
+      teamname = args[:teamname]
+      username = args[:username]
+      deploy_client = get_deploy_client(username)
+      appname = "dm-search-api-#{teamname}"
+      servicename = "#{teamname}-dm-search-api-elasticsearch"
+
+      search_api_token = DM_SEARCH_API_TOKEN
+
+      LOGGER.info("Deploying #{appname}")
+      deploy_client.deploy_app(
+        app: {
+          name: appname,
+          dir: File.join(REPOS_DIR, "digitalmarketplace-search-api"),
+          platform: "python"
+        },
+        env_vars: {
+          DM_SEARCH_API_AUTH_TOKEN: search_api_token,
+        },
+        elasticsearch: servicename,
+        units: UNITS_PER_APP
+      )
+    end
+    desc "Remove Datamarket Search API - dm-search-api"
+    task "remove", [ :teamname, :username ] do |t, args|
+      teamname = args[:teamname]
+      username = args[:username]
+      deploy_client = get_deploy_client(username)
+      appname = "dm-search-api-#{teamname}"
+      servicename = "#{teamname}-dm-search-api-elasticsearch"
+
+      deploy_client.remove_app(
+        app: {
+          name: appname,
+        },
+        elasticsearch: servicename,
+      )
+    end
+  end
   namespace "dm-api" do
     desc "Deploy Datamarket API (no db dump) - dm-api"
     task "deploy_app", [ :teamname, :username ] do |t, args|
@@ -314,7 +355,7 @@ namespace "apps" do
 
       api_token = DM_API_TOKEN
       search_api_token = DM_SEARCH_API_TOKEN
-      search_api_url = DM_SEARCH_API_URL
+      search_api_url = "https://" + deploy_client.api_client.get_app_url("dm-search-api-#{teamname}")
 
       LOGGER.info("Deploying #{appname}")
       deploy_client.deploy_app(
@@ -344,6 +385,16 @@ namespace "apps" do
 
       LOGGER.info("Importing #{pg_dump_url} in service of #{appname}")
       deploy_client.import_pg_dump(appname, pg_dump_url, pg_dump_auth_header)
+    end
+
+    desc "Import Data To Elasticsearch"
+    task "import_elasticsearch" do |t, args|
+      teamname = args[:teamname]
+      username = args[:username]
+      deploy_client = get_deploy_client(username)
+      from_appname = "dm-api-#{teamname}"
+      to_appname = "dm-search0api-#{teamname}"
+      deploy_client.import_elasticsearch_data(from_appname, to_appname)
     end
 
     # Aggregates both tasks
@@ -379,7 +430,7 @@ namespace "apps" do
 
       api_token = DM_API_TOKEN
       search_api_token = DM_SEARCH_API_TOKEN
-      search_api_url = DM_SEARCH_API_URL
+      search_api_url = "https://" + deploy_client.api_client.get_app_url("dm-search-api-#{teamname}")
       api_url = "https://" + deploy_client.api_client.get_app_url("dm-api-#{teamname}")
 
       LOGGER.info("Deploying #{appname}")
@@ -427,7 +478,7 @@ namespace "apps" do
 
       api_token = DM_API_TOKEN
       search_api_token = DM_SEARCH_API_TOKEN
-      search_api_url = DM_SEARCH_API_URL
+      search_api_url = "https://" + deploy_client.api_client.get_app_url("dm-search-api-#{teamname}")
       api_url = "https://" + deploy_client.api_client.get_app_url("dm-api-#{teamname}")
 
       deploy_client.deploy_app(
@@ -472,7 +523,7 @@ namespace "apps" do
 
       api_token = DM_API_TOKEN
       search_api_token = DM_SEARCH_API_TOKEN
-      search_api_url = DM_SEARCH_API_URL
+      search_api_url = "https://" + deploy_client.api_client.get_app_url("dm-search-api-#{teamname}")
       api_url = "https://" + deploy_client.api_client.get_app_url("dm-api-#{teamname}")
 
       deploy_client.deploy_app(
@@ -515,6 +566,7 @@ end
 app_list = [
   "flask-app",
   "java-app",
+  "dm-search-api",
   "dm-api",
   "dm-supplier-frontend",
   "dm-buyer-frontend",

--- a/bulk_deploy/tsuru_api_client.rb
+++ b/bulk_deploy/tsuru_api_client.rb
@@ -103,7 +103,7 @@ class TsuruAPIClient
       }
     )
   end
-  
+
   def list_keys()
     response = request_json(
       method: :get,
@@ -219,15 +219,11 @@ class TsuruAPIClient
   end
 
   def add_units(units, app_name)
-    objects = request_json(
+    request_json(
       method: :put,
       path: "/apps/#{app_name}/units",
       body: units.to_s
     )
-
-    for obj in objects
-      @logger.debug(obj["Message"])
-    end
   end
 
   def remove_units(units, app_name)
@@ -268,7 +264,7 @@ class TsuruAPIClient
   end
 
   def set_env_var(app_name, key, value)
-    request_json(
+    request(
       method: :post,
       path: "/apps/#{app_name}/env",
       params: {
@@ -306,6 +302,13 @@ class TsuruAPIClient
     request(
       method: :delete,
       path: "/apps/#{name}"
+    )
+  end
+
+  def unlock_app(app_name)
+    request(
+      method: :delete,
+      path: "/apps/#{app_name}/lock"
     )
   end
 

--- a/bulk_deploy/tsuru_api_client.rb
+++ b/bulk_deploy/tsuru_api_client.rb
@@ -101,6 +101,10 @@ class TsuruAPIClient
     )
   end
 
+  def has_key()
+    get_keys().has_key?("rsa")
+  end
+
   def remove_key()
     request_json(
       method: :delete,

--- a/bulk_deploy/tsuru_api_client.rb
+++ b/bulk_deploy/tsuru_api_client.rb
@@ -94,6 +94,23 @@ class TsuruAPIClient
     )
   end
 
+  def get_keys()
+    request_json(
+      method: :get,
+      path: "/users/keys",
+    )
+  end
+
+  def remove_key()
+    request_json(
+      method: :delete,
+      path: "/users/keys",
+      params: {
+        :name => "rsa",
+      }
+    )
+  end
+
   def create_team(team)
     response = request_json(
       method: :post,

--- a/bulk_deploy/tsuru_api_service.rb
+++ b/bulk_deploy/tsuru_api_service.rb
@@ -65,6 +65,7 @@ class TsuruAPIService
 
     new_api_client = self.api_client.clone
     new_api_client.login(user[:email], user[:password])
+    new_api_client.remove_key()
     new_api_client.add_key(public_key)
 
     user[:key] = ssh_id_rsa_path

--- a/bulk_deploy/tsuru_api_service.rb
+++ b/bulk_deploy/tsuru_api_service.rb
@@ -65,7 +65,10 @@ class TsuruAPIService
 
     new_api_client = self.api_client.clone
     new_api_client.login(user[:email], user[:password])
-    new_api_client.remove_key()
+
+    if new_api_client.has_key()
+      new_api_client.remove_key()
+    end
     new_api_client.add_key(public_key)
 
     user[:key] = ssh_id_rsa_path

--- a/bulk_deploy/tsuru_deploy_client.rb
+++ b/bulk_deploy/tsuru_deploy_client.rb
@@ -171,11 +171,10 @@ class TsuruDeployClient
 
   def import_elasticsearch_data(pg_app_name, es_app_name)
     search_api_url = "https://" + api_client.get_app_url(es_app_name)
-    search_api_token = api_client.get_env_vars(es_app_name)["DM_SEARCH_API_AUTH_TOKEN"]
+    search_api_token = api_client.get_env_vars(es_app_name)["DM_SEARCH_API_AUTH_TOKENS"]
     api_url = "http://0.0.0.0:8888"
     api_token = api_client.get_env_vars(pg_app_name)["DM_API_AUTH_TOKENS"]
     remote_command = "python scripts/index_services.py #{search_api_url} #{search_api_token} #{api_url} #{api_token} --serial"
-    print remote_command
     tsuru_command.app_run_once(pg_app_name, remote_command)
     raise tsuru_command.stderr if tsuru_command.exit_status != 0
   end

--- a/bulk_deploy/tsuru_deploy_client.rb
+++ b/bulk_deploy/tsuru_deploy_client.rb
@@ -168,7 +168,9 @@ class TsuruDeployClient
       "  psql ${PG_DATABASE} -h ${PG_HOST} -p ${PG_PORT} -U ${PG_USER} -t -c 'SELECT count(*) > 2000 from services;' | grep -q t )"
     self.logger.info("Going to import Postgres data")
     tsuru_command.app_run_once(app_name, remote_command)
-    raise tsuru_command.stderr if tsuru_command.exit_status != 0
+    if tsuru_command.exit_status != 0
+      self.logger.error(tsuru_command.stderr)
+    end
   end
 
   def import_elasticsearch_data(pg_app_name, es_app_name)
@@ -179,7 +181,9 @@ class TsuruDeployClient
     remote_command = "python scripts/index_services.py #{search_api_url} #{search_api_token} #{api_url} #{api_token} --serial"
     self.logger.info("Going to import Elasticsearch data")
     tsuru_command.app_run_once(pg_app_name, remote_command)
-    raise tsuru_command.stderr if tsuru_command.exit_status != 0
+    if tsuru_command.exit_status != 0
+      self.logger.error(tsuru_command.stderr)
+    end
   end
 
 end

--- a/bulk_deploy/tsuru_deploy_client.rb
+++ b/bulk_deploy/tsuru_deploy_client.rb
@@ -51,7 +51,7 @@ class TsuruDeployClient
 
   end
 
-  def deploy_app(app:, env_vars: {}, postgres: '', elasticsearch: '', git: false, units: 3)
+  def deploy_app(app:, env_vars: {}, postgres: '', elasticsearch: '', git: false)
     self.logger.info("Going to deploy #{app[:name]}. Check #{@tsuru_output.path} for output.")
 
     if not api_client.list_apps().include? app[:name]
@@ -62,50 +62,57 @@ class TsuruDeployClient
 
     # Check if the app is already running, skip if it is
     deployed_units = self.api_client.get_app_info(app[:name])["units"].length
-    if deployed_units > 1
+    if deployed_units > 0
       self.logger.info("#{app[:name]} is already deployed, skipping. Remove app to redeploy.")
-    else
-      # Set environment variables, if needed
-      if env_vars.length > 0
-        env_vars.each do |key,value|
-          api_client.set_env_var(app[:name], key, value)
-        end
-      end
+      return
+    end
 
-      if postgres != ''
-        bind_service_to_app("postgresql", postgres, app)
-      end
-
-      if elasticsearch != ''
-        bind_service_to_app("elasticsearch", elasticsearch, app)
-      end
-
-      if git
-        self.logger.info("Deploy #{app[:name]} via git. Check #{@tsuru_output.path} for output.")
-        git_command = GitCommandLine.new(app[:dir], {
-          'HOME' => tsuru_home,
-          'GIT_SSH' => ssh_wrapper
-        },
-        {
-          :verbose => ENV['VERBOSE'],
-          :output_file => tsuru_command.output_file
-        })
-        git_command.push(api_client.get_app_repository(app[:name]))
-        raise git_command.stderr if git_command.exit_status != 0
-      else
-        self.logger.info("Deploy #{app[:name]} via app-deploy. Check #{@tsuru_output.path} for output.")
-        tsuru_command.app_deploy(app[:name], app[:dir], '*')
-        raise tsuru_command.stderr if tsuru_command.exit_status != 0
+    # Set environment variables, if needed
+    if env_vars.length > 0
+      env_vars.each do |key,value|
+        api_client.set_env_var(app[:name], key, value)
       end
     end
 
-    deployed_units = self.api_client.get_app_info(app[:name])["units"].length
-    if deployed_units < units
-      self.logger.info("Increasing units of #{app[:name]} #{deployed_units} => #{units}")
-      api_client.add_units(units - deployed_units, app[:name])
+    if postgres != ''
+      bind_service_to_app("postgresql", postgres, app)
+    end
+
+    if elasticsearch != ''
+      bind_service_to_app("elasticsearch", elasticsearch, app)
+    end
+
+    if git
+      self.logger.info("Deploy #{app[:name]} via git. Check #{@tsuru_output.path} for output.")
+      git_command = GitCommandLine.new(app[:dir], {
+        'HOME' => tsuru_home,
+        'GIT_SSH' => ssh_wrapper
+      },
+      {
+        :verbose => ENV['VERBOSE'],
+        :output_file => tsuru_command.output_file
+      })
+      git_command.push(api_client.get_app_repository(app[:name]))
+      raise git_command.stderr if git_command.exit_status != 0
+    else
+      self.logger.info("Deploy #{app[:name]} via app-deploy. Check #{@tsuru_output.path} for output.")
+      tsuru_command.app_deploy(app[:name], app[:dir], '*')
+      raise tsuru_command.stderr if tsuru_command.exit_status != 0
     end
 
     self.logger.info("Finished deploying #{app[:name]}")
+  end
+
+  def add_units(app_name:, units: 3)
+    deployed_units = api_client.get_app_info(app_name)["units"].length
+
+    if deployed_units >= units
+      self.logger.info("#{app_name} already has enough units, skipping.")
+      return
+    end
+
+    self.logger.info("Increasing units of #{app_name} #{deployed_units} => #{units}")
+    api_client.add_units(units - deployed_units, app_name)
   end
 
   def bind_service_to_app(service_name, instance_name, app)
@@ -120,13 +127,11 @@ class TsuruDeployClient
     end
   end
 
-  def remove_app(app:, postgres: '', elasticsearch: '')
-    self.logger.info("Going to remove #{app[:name]}")
+  def remove_app(app_name:, postgres: '', elasticsearch: '')
+    self.logger.info("Going to remove #{app_name}")
 
-    if api_client.list_apps().include? app[:name]
-      self.logger.warn("Application #{app[:name]} does not exist " \
-                       "on the platform #{app[:platform]}")
-      tsuru_command.app_remove(app[:name])
+    if api_client.list_apps().include? app_name
+      tsuru_command.app_remove(app_name)
       raise tsuru_command.stderr if tsuru_command.exit_status != 0
     end
 
@@ -167,6 +172,7 @@ class TsuruDeployClient
       "( pg_restore -O -a -h ${PG_HOST} -p ${PG_PORT} -U ${PG_USER} -d ${PG_DATABASE} || "\
       "  psql ${PG_DATABASE} -h ${PG_HOST} -p ${PG_PORT} -U ${PG_USER} -t -c 'SELECT count(*) > 2000 from services;' | grep -q t )"
     self.logger.info("Going to import Postgres data")
+    tsuru_command.app_run_once(app_name, remote_command)
     tsuru_command.app_run_once(app_name, remote_command)
     if tsuru_command.exit_status != 0
       self.logger.error(tsuru_command.stderr)

--- a/bulk_deploy/tsuru_deploy_client.rb
+++ b/bulk_deploy/tsuru_deploy_client.rb
@@ -165,6 +165,7 @@ class TsuruDeployClient
       "curl #{dump_url} -H '#{auth_header}' | "\
       "( pg_restore -O -a -h ${PG_HOST} -p ${PG_PORT} -U ${PG_USER} -d ${PG_DATABASE} || "\
       "  psql ${PG_DATABASE} -h ${PG_HOST} -p ${PG_PORT} -U ${PG_USER} -t -c 'SELECT count(*) > 2000 from users;' | grep -q t )"
+    self.logger.info("Going to import Postgres data")
     tsuru_command.app_run_once(app_name, remote_command)
     raise tsuru_command.stderr if tsuru_command.exit_status != 0
   end
@@ -175,6 +176,7 @@ class TsuruDeployClient
     api_url = "http://0.0.0.0:8888"
     api_token = api_client.get_env_vars(pg_app_name)["DM_API_AUTH_TOKENS"]
     remote_command = "python scripts/index_services.py #{search_api_url} #{search_api_token} #{api_url} #{api_token} --serial"
+    self.logger.info("Going to import Elasticsearch data")
     tsuru_command.app_run_once(pg_app_name, remote_command)
     raise tsuru_command.stderr if tsuru_command.exit_status != 0
   end

--- a/bulk_deploy/tsuru_deploy_client.rb
+++ b/bulk_deploy/tsuru_deploy_client.rb
@@ -95,6 +95,7 @@ class TsuruDeployClient
       else
         self.logger.info("Deploy #{app[:name]} via app-deploy. Check #{@tsuru_output.path} for output.")
         tsuru_command.app_deploy(app[:name], app[:dir], '*')
+        raise tsuru_command.stderr if tsuru_command.exit_status != 0
       end
     end
 

--- a/bulk_deploy/tsuru_deploy_client.rb
+++ b/bulk_deploy/tsuru_deploy_client.rb
@@ -172,10 +172,11 @@ class TsuruDeployClient
   def import_elasticsearch_data(pg_app_name, es_app_name)
     search_api_url = "https://" + api_client.get_app_url(es_app_name)
     search_api_token = api_client.get_env_vars(es_app_name)["DM_SEARCH_API_AUTH_TOKEN"]
-    api_url = "https://" + api_client.get_app_url(pg_app_name)
+    api_url = "http://0.0.0.0:8888"
     api_token = api_client.get_env_vars(pg_app_name)["DM_API_AUTH_TOKENS"]
-    remote_command = "python scripts/index_services.py #{search_api_url} #{search_api_token} #{api_url} #{api_token}"
-    tsuru_command.app_run_once(app_name, remote_command)
+    remote_command = "python scripts/index_services.py #{search_api_url} #{search_api_token} #{api_url} #{api_token} --serial"
+    print remote_command
+    tsuru_command.app_run_once(pg_app_name, remote_command)
     raise tsuru_command.stderr if tsuru_command.exit_status != 0
   end
 

--- a/bulk_deploy/tsuru_deploy_client.rb
+++ b/bulk_deploy/tsuru_deploy_client.rb
@@ -165,7 +165,7 @@ class TsuruDeployClient
       "echo \"*:*:*:${PG_PASSWORD}\" > ~/.pgpass && chmod 600 ~/.pgpass && "\
       "curl #{dump_url} -H '#{auth_header}' | "\
       "( pg_restore -O -a -h ${PG_HOST} -p ${PG_PORT} -U ${PG_USER} -d ${PG_DATABASE} || "\
-      "  psql ${PG_DATABASE} -h ${PG_HOST} -p ${PG_PORT} -U ${PG_USER} -t -c 'SELECT count(*) > 2000 from users;' | grep -q t )"
+      "  psql ${PG_DATABASE} -h ${PG_HOST} -p ${PG_PORT} -U ${PG_USER} -t -c 'SELECT count(*) > 2000 from services;' | grep -q t )"
     self.logger.info("Going to import Postgres data")
     tsuru_command.app_run_once(app_name, remote_command)
     raise tsuru_command.stderr if tsuru_command.exit_status != 0


### PR DESCRIPTION
# What

Added the search API app to the list of deployed apps and a task to import Elasticsearch data.

The deployment script works the same way as explained in the README file.

All frontend apps have been reconfigured to point to the correct Elasticsearch endpoint.
# How To Test

On a clean environment in working state (check that Elasticsearch service and broker are running after resuming a previously stopped environment):

```
bundle install
bundle exec rake \
    admin_pass=mysecretpass \
    environment=test host=tsuru.paas.alphagov.co.uk \
    num_users=10 num_teams=2 \
    dm_api_pg_dump_url="http://somehost.com/full.dump" \
    dm_api_pg_dump_auth_header="Auth: ..." \
    deploy  
```
# Who To Review

Somebody other than @RichardKnop
