### PR TITLE
[#100298492] Performance test bulk_deploy issues in team creation/deletion

### DIFF
--- a/bulk_deploy/Rakefile
+++ b/bulk_deploy/Rakefile
@@ -192,8 +192,12 @@ namespace :teams do |ns|
             end
             desc "Remove user #{username} in team #{teamname}"
             task :remove => [ "tsuru:login_admin" ] do
-              LOGGER.info("Remove user #{username}")
-              @api_client.remove_user(username)
+              if @api_client.user_exists(username)
+                LOGGER.info("Remove user #{username}")
+                @api_client.remove_user(username)
+              else
+                LOGGER.info("User #{username} does not exist, not removing.")
+              end
             end
           end
         }
@@ -210,8 +214,13 @@ namespace :teams do |ns|
       end
       desc "Remove team #{teamname}"
       task :remove => [ "tsuru:login_admin", "#{namespace_name}:users:remove_all" ] do
-        LOGGER.info("Remove team #{teamname}")
-        @api_client.remove_team(teamname)
+        if @api_client.list_teams().include? teamname
+          LOGGER.info("Remove team #{teamname}")
+          @api_client.remove_team(teamname)
+        else
+          LOGGER.info("Team #{teamname} does not exist, not removing.")
+        end
+
       end
     end
   }

--- a/bulk_deploy/tsuru_api_client.rb
+++ b/bulk_deploy/tsuru_api_client.rb
@@ -83,13 +83,13 @@ class TsuruAPIClient
     return false
   end
 
-  def add_key(pubkey)
+  def add_key(name, pubkey)
     request_json(
       method: :post,
       path: "/users/keys",
       params: {
         :key => pubkey,
-        :name => "rsa",
+        :name => name,
       }
     )
   end

--- a/bulk_deploy/tsuru_api_client.rb
+++ b/bulk_deploy/tsuru_api_client.rb
@@ -94,6 +94,30 @@ class TsuruAPIClient
     )
   end
 
+  def remove_key(name)
+    request_json(
+      method: :delete,
+      path: "/users/keys",
+      params: {
+        :name => name,
+      }
+    )
+  end
+
+  def list_keys()
+    response = request_json(
+      method: :get,
+      path: "/users/keys"
+    )
+
+    keys = Array.new()
+    response.each do |key, val|
+      keys.push(key)
+    end
+
+    return keys
+  end
+
   def create_team(team)
     response = request_json(
       method: :post,

--- a/bulk_deploy/tsuru_api_service.rb
+++ b/bulk_deploy/tsuru_api_service.rb
@@ -65,7 +65,8 @@ class TsuruAPIService
 
     new_api_client = self.api_client.clone
     new_api_client.login(user[:email], user[:password])
-    new_api_client.add_key(public_key)
+
+    new_api_client.add_key("rsa", public_key)
 
     user[:key] = ssh_id_rsa_path
     user[:ssh_wrapper] = ssh_wrapper_path

--- a/bulk_deploy/tsuru_api_service.rb
+++ b/bulk_deploy/tsuru_api_service.rb
@@ -66,6 +66,10 @@ class TsuruAPIService
     new_api_client = self.api_client.clone
     new_api_client.login(user[:email], user[:password])
 
+    if new_api_client.list_keys().include? "rsa"
+      self.logger.info("Deleting old key 'rsa' for user #{user[:email]}")
+      new_api_client.remove_key("rsa")
+    end
     new_api_client.add_key("rsa", public_key)
 
     user[:key] = ssh_id_rsa_path


### PR DESCRIPTION
[#100298492 Performance test bulk_deploy issues in team creation/deletion(https://www.pivotaltracker.com/n/projects/1275640/stories/100298492)
## What

There are [two issues in `tsuru-performance-test`](https://github.com/alphagov/tsuru-performance-tests/tree/master/bulk_deploy): 
1. If you rerun `teams:create_all`, it fails because it cannot override the key of the user. It should delete the existing key and add the new one.
2. If you run `teams:remove_all` and there are missing users (e.g. `num_users=100 num_teams=3 teams:remove_all`)
## How to review this PR
1. You should be able to run several times `teams:create_all` task with different arguments for `num_users` and `num_teams`.
2. You should be able to run several times `teams:remove_all` task with different arguments for `num_users` and `num_teams`.

For that, try to run:

```
ADMIN_PASS=secretpass
DEPLOY_ENV=yourenv
HOST_SUFFIX=tsuru.paas.alphagov.co.uk # for AWS

rake  \
 admin_pass=$ADMIN_PASS environment=$DEPLOY_ENV host=$HOST_PREFIX \
 num_users=4 num_teams=3  \
 VERBOSE=true teams:create_all

rake  \
 admin_pass=$ADMIN_PASS environment=$DEPLOY_ENV host=$HOST_PREFIX \
 num_users=4 num_teams=3  \
 VERBOSE=true teams:create_all

rake  \
 admin_pass=$ADMIN_PASS environment=$DEPLOY_ENV host=$HOST_PREFIX \
 num_users=4 num_teams=3  \
 VERBOSE=true teams:remove_all

rake  \
 admin_pass=$ADMIN_PASS environment=$DEPLOY_ENV host=$HOST_PREFIX \
 num_users=4 num_teams=3  \
 VERBOSE=true teams:remove_all

```
### who can review this?

Anyone but @keymon
